### PR TITLE
don't use hardcoded bash path

### DIFF
--- a/configure
+++ b/configure
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Anticonf (tm) script by Jeroen Ooms (2017)
 # This script will query 'pkg-config' for the required cflags and ldflags.
 # If pkg-config is unavailable or does not find the library, try setting


### PR DESCRIPTION
Avoid using hard coded bash path in `configure` for systems which don't have bash in `/bin/bash` (in my case FreeBSD).