### PR TITLE
Support for long vectors

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: sodium
 Type: Package
 Title: A Modern and Easy-to-Use Crypto Library
-Version: 1.2.0
+Version: 1.2.1
 Author: Jeroen Ooms
 Maintainer: Jeroen Ooms <jeroen@berkeley.edu>
 Description: Bindings to 'libsodium': a modern, easy-to-use software library for

--- a/src/hashing.c
+++ b/src/hashing.c
@@ -5,7 +5,7 @@
 
 SEXP R_sha256(SEXP buf){
   SEXP res = allocVector(RAWSXP, crypto_hash_sha256_BYTES);
-  if(crypto_hash_sha256(RAW(res), RAW(buf), LENGTH(buf)))
+  if(crypto_hash_sha256(RAW(res), RAW(buf), XLENGTH(buf)))
     Rf_error("Failed to hash");
   return res;
 }
@@ -14,7 +14,7 @@ SEXP R_auth_sha256(SEXP buf, SEXP key){
   if(LENGTH(key) != crypto_auth_hmacsha256_BYTES)
     Rf_error("Invalid key, must be exactly %d bytes", crypto_auth_hmacsha256_BYTES);
   SEXP res = allocVector(RAWSXP, crypto_hash_sha256_BYTES);
-  if(crypto_auth_hmacsha256(RAW(res), RAW(buf), LENGTH(buf), RAW(key)))
+  if(crypto_auth_hmacsha256(RAW(res), RAW(buf), XLENGTH(buf), RAW(key)))
     Rf_error("Failed to hash");
   return res;
 }
@@ -23,7 +23,7 @@ SEXP R_auth_sha256(SEXP buf, SEXP key){
 
 SEXP R_sha512(SEXP buf){
   SEXP res = allocVector(RAWSXP, crypto_hash_sha512_BYTES);
-  if(crypto_hash_sha512(RAW(res), RAW(buf), LENGTH(buf)))
+  if(crypto_hash_sha512(RAW(res), RAW(buf), XLENGTH(buf)))
     Rf_error("Failed to hash");
   return res;
 }
@@ -32,7 +32,7 @@ SEXP R_auth_sha512(SEXP buf, SEXP key){
   if(LENGTH(key) != crypto_auth_hmacsha512_BYTES)
     Rf_error("Invalid key, must be exactly %d bytes", crypto_auth_hmacsha512_BYTES);
   SEXP res = allocVector(RAWSXP, crypto_hash_sha512_BYTES);
-  if(crypto_auth_hmacsha512(RAW(res), RAW(buf), LENGTH(buf), RAW(key)))
+  if(crypto_auth_hmacsha512(RAW(res), RAW(buf), XLENGTH(buf), RAW(key)))
     Rf_error("Failed to hash");
   return res;
 }
@@ -54,7 +54,7 @@ SEXP R_crypto_generichash(SEXP buf, SEXP size, SEXP key){
   }
 
   SEXP res = allocVector(RAWSXP, outlen);
-  if(crypto_generichash(RAW(res), outlen, RAW(buf), LENGTH(buf), keyval, keysize))
+  if(crypto_generichash(RAW(res), outlen, RAW(buf), XLENGTH(buf), keyval, keysize))
     Rf_error("Failed to hash");
   return res;
 }
@@ -66,7 +66,7 @@ SEXP R_crypto_shorthash(SEXP buf, SEXP key){
     Rf_error("Invalid key, must be exactly %d bytes", crypto_shorthash_KEYBYTES);
 
   SEXP res = allocVector(RAWSXP, crypto_shorthash_BYTES);
-  if(crypto_shorthash(RAW(res), RAW(buf), LENGTH(buf), RAW(key)))
+  if(crypto_shorthash(RAW(res), RAW(buf), XLENGTH(buf), RAW(key)))
     Rf_error("Failed to hash");
   return res;
 }
@@ -78,7 +78,7 @@ SEXP R_pwhash(SEXP buf, SEXP salt, SEXP size){
   if(LENGTH(salt) != crypto_pwhash_scryptsalsa208sha256_SALTBYTES)
     Rf_error("Invalid salt, must be exactly %d bytes", crypto_pwhash_scryptsalsa208sha256_SALTBYTES);
   SEXP res = allocVector(RAWSXP, outlen);
-  if(crypto_pwhash_scryptsalsa208sha256(RAW(res), outlen, (char*) RAW(buf), LENGTH(buf), RAW(salt),
+  if(crypto_pwhash_scryptsalsa208sha256(RAW(res), outlen, (char*) RAW(buf), XLENGTH(buf), RAW(salt),
   crypto_pwhash_scryptsalsa208sha256_OPSLIMIT_INTERACTIVE, crypto_pwhash_scryptsalsa208sha256_MEMLIMIT_INTERACTIVE))
     Rf_error("pwhash failed");
   return res;
@@ -92,7 +92,7 @@ SEXP R_pwhash_argon2(SEXP buf, SEXP salt, SEXP size){
   if(LENGTH(salt) != crypto_pwhash_SALTBYTES)
     Rf_error("Invalid salt, must be exactly %d bytes", crypto_pwhash_SALTBYTES);
   SEXP res = allocVector(RAWSXP, outlen);
-  if(crypto_pwhash(RAW(res), outlen, (char*) RAW(buf), LENGTH(buf), RAW(salt),
+  if(crypto_pwhash(RAW(res), outlen, (char*) RAW(buf), XLENGTH(buf), RAW(salt),
                    crypto_pwhash_OPSLIMIT_INTERACTIVE,
                    crypto_pwhash_MEMLIMIT_INTERACTIVE,
                    crypto_pwhash_ALG_ARGON2I13))

--- a/src/messaging.c
+++ b/src/messaging.c
@@ -8,10 +8,10 @@ SEXP R_secure_send(SEXP msg, SEXP key, SEXP pubkey, SEXP nonce) {
     Rf_error("Invalid pubkey, must be exactly %d bytes", crypto_box_PUBLICKEYBYTES);
   if(LENGTH(nonce) != crypto_box_NONCEBYTES)
     Rf_error("Invalid nonce, must be exactly %d bytes", crypto_box_NONCEBYTES);
-  int mlen = LENGTH(msg);
-  int clen = mlen + crypto_box_MACBYTES;
+  R_xlen_t mlen = XLENGTH(msg);
+  R_xlen_t clen = mlen + crypto_box_MACBYTES;
   SEXP res = allocVector(RAWSXP, clen);
-  if(crypto_box_easy(RAW(res), RAW(msg), LENGTH(msg), RAW(nonce), RAW(pubkey), RAW(key)))
+  if(crypto_box_easy(RAW(res), RAW(msg), XLENGTH(msg), RAW(nonce), RAW(pubkey), RAW(key)))
     Rf_error("Authenticated encryption failed");
   return res;
 }
@@ -23,10 +23,10 @@ SEXP R_secure_recv(SEXP cipher, SEXP key, SEXP pubkey, SEXP nonce){
     Rf_error("Invalid pubkey, must be exactly %d bytes", crypto_box_PUBLICKEYBYTES);
   if(LENGTH(nonce) != crypto_box_NONCEBYTES)
     Rf_error("Invalid nonce, must be exactly %d bytes", crypto_box_NONCEBYTES);
-  int clen = LENGTH(cipher);
-  int mlen = clen - crypto_box_MACBYTES;
+  R_xlen_t clen = XLENGTH(cipher);
+  R_xlen_t mlen = clen - crypto_box_MACBYTES;
   SEXP res = allocVector(RAWSXP, mlen);
-  if(crypto_box_open_easy(RAW(res), RAW(cipher), LENGTH(cipher), RAW(nonce), RAW(pubkey), RAW(key)))
+  if(crypto_box_open_easy(RAW(res), RAW(cipher), XLENGTH(cipher), RAW(nonce), RAW(pubkey), RAW(key)))
     Rf_error("Authenticated decryption failed");
   return res;
 }

--- a/src/seal.c
+++ b/src/seal.c
@@ -4,8 +4,8 @@
 SEXP R_seal_box(SEXP msg, SEXP pubkey){
   if(LENGTH(pubkey) != crypto_box_PUBLICKEYBYTES)
     Rf_error("Invalid pubkey, must be exactly %d bytes", crypto_box_PUBLICKEYBYTES);
-  int mlen = LENGTH(msg);
-  int clen = mlen + crypto_box_SEALBYTES;
+  R_xlen_t mlen = XLENGTH(msg);
+  R_xlen_t clen = mlen + crypto_box_SEALBYTES;
   SEXP res = allocVector(RAWSXP, clen);
   if(crypto_box_seal(RAW(res), RAW(msg), mlen, RAW(pubkey)))
     Rf_error("Failed to encrypt");
@@ -15,8 +15,8 @@ SEXP R_seal_box(SEXP msg, SEXP pubkey){
 SEXP R_seal_open(SEXP cipher, SEXP key){
   if(LENGTH(key) != crypto_box_SECRETKEYBYTES)
     Rf_error("Invalid key, must be exactly %d bytes", crypto_box_SECRETKEYBYTES);
-  int clen = LENGTH(cipher);
-  int mlen = clen - crypto_box_SEALBYTES;
+  R_xlen_t clen = XLENGTH(cipher);
+  R_xlen_t mlen = clen - crypto_box_SEALBYTES;
   SEXP res = allocVector(RAWSXP, mlen);
   unsigned char pk[crypto_box_PUBLICKEYBYTES];
   crypto_scalarmult_base(pk, RAW(key));

--- a/src/secret.c
+++ b/src/secret.c
@@ -8,8 +8,8 @@ SEXP R_crypto_secret_encrypt(SEXP message, SEXP key, SEXP nonce){
   if(LENGTH(nonce) != crypto_secretbox_NONCEBYTES)
     Rf_error("Invalid nonce: must be exactly %d bytes", crypto_secretbox_NONCEBYTES);
 
-  int mlen = LENGTH(message);
-  int clen = mlen + crypto_secretbox_MACBYTES;
+  R_xlen_t mlen = XLENGTH(message);
+  R_xlen_t clen = mlen + crypto_secretbox_MACBYTES;
   SEXP res = allocVector(RAWSXP, clen);
 
   if(crypto_secretbox_easy(RAW(res), RAW(message), mlen, RAW(nonce), RAW(key)))
@@ -24,8 +24,8 @@ SEXP R_crypto_secret_decrypt(SEXP cipher, SEXP key, SEXP nonce){
   if(LENGTH(nonce) != crypto_secretbox_NONCEBYTES)
     Rf_error("Invalid key. Key must be exactly %d bytes", crypto_secretbox_NONCEBYTES);
 
-  int clen = LENGTH(cipher);
-  int mlen = clen - crypto_secretbox_MACBYTES;
+  R_xlen_t clen = XLENGTH(cipher);
+  R_xlen_t mlen = clen - crypto_secretbox_MACBYTES;
   SEXP res = allocVector(RAWSXP, mlen);
 
   if(crypto_secretbox_open_easy(RAW(res), RAW(cipher), clen, RAW(nonce), RAW(key)))
@@ -40,7 +40,7 @@ SEXP R_crypto_secret_auth(SEXP message, SEXP key){
 
   SEXP res = allocVector(RAWSXP, crypto_auth_BYTES);
 
-  if(crypto_auth(RAW(res), RAW(message), LENGTH(message), RAW(key)))
+  if(crypto_auth(RAW(res), RAW(message), XLENGTH(message), RAW(key)))
     Rf_error("Authentication failed.");
 
   return res;
@@ -52,6 +52,6 @@ SEXP R_crypto_secret_verify(SEXP message, SEXP key, SEXP tag){
   if(LENGTH(tag) != crypto_auth_BYTES)
     Rf_error("Invalid tag. Key must be exactly %d bytes", crypto_auth_BYTES);
 
-  int res = crypto_auth_verify(RAW(tag), RAW(message), LENGTH(message), RAW(key));
+  int res = crypto_auth_verify(RAW(tag), RAW(message), XLENGTH(message), RAW(key));
   return ScalarLogical(res == 0);
 }

--- a/src/signing.c
+++ b/src/signing.c
@@ -24,7 +24,7 @@ SEXP R_sig_sign(SEXP msg, SEXP key){
   if(LENGTH(key) != crypto_sign_SECRETKEYBYTES)
     Rf_error("Invalid key: must be exactly %d bytes", crypto_sign_SECRETKEYBYTES);
   SEXP res = allocVector(RAWSXP, crypto_sign_BYTES);
-  if(crypto_sign_detached(RAW(res), NULL, RAW(msg), LENGTH(msg), RAW(key)))
+  if(crypto_sign_detached(RAW(res), NULL, RAW(msg), XLENGTH(msg), RAW(key)))
     Rf_error("Failed to create signature");
   return res;
 }
@@ -34,7 +34,7 @@ SEXP R_sig_verify(SEXP msg, SEXP sig, SEXP pubkey){
     Rf_error("Invalid pubkey: must be exactly %d bytes", crypto_sign_PUBLICKEYBYTES);
   if(LENGTH(sig) != crypto_sign_BYTES)
     Rf_error("Invalid sig: must be exactly %d bytes", crypto_sign_BYTES);
-  if(crypto_sign_verify_detached(RAW(sig), RAW(msg), LENGTH(msg), RAW(pubkey)))
+  if(crypto_sign_verify_detached(RAW(sig), RAW(msg), XLENGTH(msg), RAW(pubkey)))
     Rf_error("Signature verification failed");
   return ScalarLogical(TRUE);
 }


### PR DESCRIPTION
Currently (v1.2.0) `sodium::data_encrypt` is limited to encrypting vectors of length 2^31-17 or less. There are two slightly separate issues here:

```
library(sodium)
key <- sha256(charToRaw("This is a secret passphrase"))
cipher <- data_encrypt(raw(2^31 - 17), key) # works fine
cipher <- data_encrypt(raw(2^31 - 16), key) # integer overflow
## Error in data_encrypt(raw(2^31 - 16), key) : 
##   negative length vectors are not allowed
cipher <- data_encrypt(raw(2^31), key) # no support for long vectors
## Error in data_encrypt(raw(2^31), key) : 
##  long vectors not supported yet: memory.c:3887
```

This PR makes minor changes to the length access and storage to prevent this, following the API in [R-ints](https://cran.r-project.org/doc/manuals/r-release/R-ints.html) where we use `XLENGTH` and type `R_xlen_t` which should be portable.

I've fairly blindly added these to the "large" components - i.e., messages and ciphertexts, but not to keys and nonces.

The package does not currently have tests, but current examples work with these changes.